### PR TITLE
Replace executable dir from '/data/local/tmp' to current running process's dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 )
 
 var (
+	expath, _   = GetExDir()
 	service     = cmdctrl.New()
 	downManager = newDownloadManager()
 	upgrader    = websocket.Upgrader{
@@ -170,6 +171,17 @@ func GoFunc(f func() error) chan error {
 	return ch
 }
 
+// Get executable directory based on current running binary
+func GetExDir() (dir string, err error) {
+	ex, err := os.Executable()
+	if err != nil {
+		log.Println("Failed to get executable directory.")
+		return "", err
+	}
+	dir = filepath.Dir(ex)
+	return dir, err
+}
+
 type MinicapInfo struct {
 	Width    int     `json:"width"`
 	Height   int     `json:"height"`
@@ -185,7 +197,8 @@ var (
 func updateMinicapRotation(rotation int) {
 	devInfo := getDeviceInfo()
 	width, height := devInfo.Display.Width, devInfo.Display.Height
-	service.UpdateArgs("minicap", "/data/local/tmp/minicap", "-S", "-P",
+	minicapbin := fmt.Sprintf("%v/%v", expath, "minicap")
+	service.UpdateArgs("minicap", minicapbin, "-S", "-P",
 		fmt.Sprintf("%dx%d@%dx%d/%d", width, height, displayMaxWidthHeight, displayMaxWidthHeight, rotation))
 }
 
@@ -246,7 +259,9 @@ func installAPKForce(path string, packageName string) error {
 }
 
 func Screenshot(filename string, thumbnailSize string) (err error) {
-	output, err := runShellOutput("LD_LIBRARY_PATH=/data/local/tmp", "/data/local/tmp/minicap", "-i")
+	ldlibrarypath := fmt.Sprintf("LD_LIBRARY_PATH=%v", expath)
+	minicapbin := fmt.Sprintf("%v/%v", expath, "minicap")
+	output, err := runShellOutput(ldlibrarypath, minicapbin, "-i")
 	if err != nil {
 		return
 	}
@@ -259,8 +274,8 @@ func Screenshot(filename string, thumbnailSize string) (err error) {
 		thumbnailSize = fmt.Sprintf("%dx%d", f.Width, f.Height)
 	}
 	if _, err = runShell(
-		"LD_LIBRARY_PATH=/data/local/tmp",
-		"/data/local/tmp/minicap",
+		ldlibrarypath,
+		minicapbin,
 		"-P", fmt.Sprintf("%dx%d@%s/%d", f.Width, f.Height, thumbnailSize, f.Rotation),
 		"-s", ">"+filename); err != nil {
 		return
@@ -1208,7 +1223,7 @@ func ServeHTTP(lis net.Listener, tunnel *TunnelProxy) error {
 
 	screenshotIndex := -1
 	nextScreenshotFilename := func() string {
-		targetFolder := "/data/local/tmp/minicap-images"
+		targetFolder := fmt.Sprintf("%v/minicap-images", expath)
 		if _, err := os.Stat(targetFolder); err != nil {
 			os.MkdirAll(targetFolder, 0755)
 		}
@@ -1276,6 +1291,10 @@ func main() {
 	fTunnelServer := flag.String("t", "", "tunnel server address")
 	fNoUiautomator := flag.Bool("nouia", false, "not start uiautomator")
 	flag.Parse()
+
+	ldlibrarypath := fmt.Sprintf("LD_LIBRARY_PATH=%v", expath)
+	minicapbin := fmt.Sprintf("%v/%v", expath, "minicap")
+	minitouchbin := fmt.Sprintf("%v/%v", expath, "minitouch")
 
 	if *fVersion {
 		fmt.Println(version)
@@ -1365,12 +1384,12 @@ func main() {
 	devInfo := getDeviceInfo()
 	width, height := devInfo.Display.Width, devInfo.Display.Height
 	service.Add("minicap", cmdctrl.CommandInfo{
-		Environ: []string{"LD_LIBRARY_PATH=/data/local/tmp"},
-		Args: []string{"/data/local/tmp/minicap", "-S", "-P",
+		Environ: []string{ldlibrarypath},
+		Args: []string{minicapbin, "-S", "-P",
 			fmt.Sprintf("%dx%d@%dx%d/0", width, height, displayMaxWidthHeight, displayMaxWidthHeight)},
 	})
 	service.Add("minitouch", cmdctrl.CommandInfo{
-		Args: []string{"/data/local/tmp/minitouch"},
+		Args: []string{minitouchbin},
 	})
 
 	// uiautomator

--- a/requirements.go
+++ b/requirements.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"regexp"
@@ -40,6 +41,8 @@ func installUiautomatorAPK() error {
 }
 
 func installMinicap() error {
+	minicapbin := fmt.Sprintf("%v/minicap", expath)
+	minicapso := fmt.Sprintf("%v/minicap.so", expath)
 	if runtime.GOOS == "windows" {
 		return nil
 	}
@@ -52,8 +55,8 @@ func installMinicap() error {
 	// 	}
 	// }
 	// remove first to prevent "text file busy"
-	os.Remove("/data/local/tmp/minicap")
-	os.Remove("/data/local/tmp/minicap.so")
+	os.Remove(minicapbin)
+	os.Remove(minicapso)
 
 	minicapSource := "https://github.com/codeskyblue/stf-binaries/raw/master/node_modules/minicap-prebuilt/prebuilt"
 	propOutput, err := runShell("getprop")
@@ -75,12 +78,12 @@ func installMinicap() error {
 		sdk = sdk + pre
 	}
 	binURL := strings.Join([]string{minicapSource, abi, "bin", "minicap"}, "/")
-	_, err = httpDownload("/data/local/tmp/minicap", binURL, 0755)
+	_, err = httpDownload(minicapbin, binURL, 0755)
 	if err != nil {
 		return err
 	}
 	libURL := strings.Join([]string{minicapSource, abi, "lib", "android-" + sdk, "minicap.so"}, "/")
-	_, err = httpDownload("/data/local/tmp/minicap.so", libURL, 0644)
+	_, err = httpDownload(minicapso, libURL, 0644)
 	if err != nil {
 		return err
 	}
@@ -88,9 +91,10 @@ func installMinicap() error {
 }
 
 func installMinitouch() error {
+	minitouchbin := fmt.Sprintf("%v/minitouch", expath)
 	baseURL := "https://github.com/codeskyblue/stf-binaries/raw/master/node_modules/minitouch-prebuilt/prebuilt"
 	abi := getCachedProperty("ro.product.cpu.abi")
 	binURL := strings.Join([]string{baseURL, abi, "bin/minitouch"}, "/")
-	_, err := httpDownload("/data/local/tmp/minitouch", binURL, 0755)
+	_, err := httpDownload(minitouchbin, binURL, 0755)
 	return err
 }


### PR DESCRIPTION
'/data/local/tmp' can be readonly on some special device like, ZUK Z2 (mostly lenovo devices), the solution is to change it to the dir of running binary, which is sure to have executable permission.

Something I'm not very confident is "/data/local/tmp/minicap-images", which looks like a data directory, I'm not sure it's usage, but in my local verification:
curl -X PUT http://someurl:7912/minitcap  // install ok
curl -X PUT http://someurl:7012/minitouch  // install ok
curl -X GET http://someurl:7912/screenshot/0 // get screenshot ok
