### PR TITLE
修改minicap的检查方式，使用-t替代-i

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,12 +175,12 @@ func GoFunc(f func() error) chan error {
 	return ch
 }
 
-type MinicapInfo struct {
-	Width    int     `json:"width"`
-	Height   int     `json:"height"`
-	Rotation int     `json:"rotation"`
-	Density  float32 `json:"density"`
-}
+//type MinicapInfo struct {
+//	Width    int     `json:"width"`
+//	Height   int     `json:"height"`
+//	Rotation int     `json:"rotation"`
+//	Density  float32 `json:"density"`
+//}
 
 var (
 	deviceRotation        int

--- a/screenshot.go
+++ b/screenshot.go
@@ -1,30 +1,50 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 )
 
+//func screenshotWithMinicap(filename, thumbnailSize string) (err error) {
+//	output, err := runShellOutput("LD_LIBRARY_PATH=/data/local/tmp", "/data/local/tmp/minicap", "-i")
+//	if err != nil {
+//		return
+//	}
+//	var f MinicapInfo
+//	if er := json.Unmarshal([]byte(output), &f); er != nil {
+//		err = fmt.Errorf("minicap not supported: %v", er)
+//		return
+//	}
+//	if thumbnailSize == "" {
+//		thumbnailSize = fmt.Sprintf("%dx%d", f.Width, f.Height)
+//	}
+//	if _, err = runShell(
+//		"LD_LIBRARY_PATH=/data/local/tmp",
+//		"/data/local/tmp/minicap",
+//		"-P", fmt.Sprintf("%dx%d@%s/%d", f.Width, f.Height, thumbnailSize, f.Rotation),
+//		"-s", ">"+filename); err != nil {
+//		err = errors.Wrap(err, "minicap")
+//		return
+//	}
+//	return nil
+//}
+
 func screenshotWithMinicap(filename, thumbnailSize string) (err error) {
-	output, err := runShellOutput("LD_LIBRARY_PATH=/data/local/tmp", "/data/local/tmp/minicap", "-i")
-	if err != nil {
+	if !isMinicapSupported() {
+		err = fmt.Errorf("minicap not supported.")
 		return
 	}
-	var f MinicapInfo
-	if er := json.Unmarshal([]byte(output), &f); er != nil {
-		err = fmt.Errorf("minicap not supported: %v", er)
-		return
-	}
+	devInfo := getDeviceInfo()
+	width, height := devInfo.Display.Width, devInfo.Display.Height
 	if thumbnailSize == "" {
-		thumbnailSize = fmt.Sprintf("%dx%d", f.Width, f.Height)
+		thumbnailSize = fmt.Sprintf("%dx%d", width, height)
 	}
 	if _, err = runShell(
 		"LD_LIBRARY_PATH=/data/local/tmp",
 		"/data/local/tmp/minicap",
-		"-P", fmt.Sprintf("%dx%d@%s/%d", f.Width, f.Height, thumbnailSize, f.Rotation),
+		"-P", fmt.Sprintf("%dx%d@%s/%d", width, height, thumbnailSize, deviceRotation),
 		"-s", ">"+filename); err != nil {
 		err = errors.Wrap(err, "minicap")
 		return
@@ -38,22 +58,49 @@ func screenshotWithScreencap(filename string) (err error) {
 	return
 }
 
+//func isMinicapSupported() bool {
+//	output, err := runShellOutput("LD_LIBRARY_PATH=/data/local/tmp", "/data/local/tmp/minicap", "-i")
+//	if err != nil {
+//		return false
+//	}
+//	var f MinicapInfo
+//	if er := json.Unmarshal([]byte(output), &f); er != nil {
+//		return false
+//	}
+//	output, err = runShell(
+//		"LD_LIBRARY_PATH=/data/local/tmp",
+//		"/data/local/tmp/minicap",
+//		"-P", fmt.Sprintf("%dx%d@%dx%d/%d", f.Width, f.Height, f.Width, f.Height, f.Rotation),
+//		"-s", "2>/dev/null")
+//	if err != nil {
+//		return false
+//	}
+//	return bytes.Equal(output[:2], []byte("\xff\xd8")) // JpegFormat
+//}
+
+/*
+检查minicap是否可用:
+使用 -t 来检测minicap是否可用，而非使用 -i，原因如下：
+
+-t : Attempt to get the capture method running, then exit.
+-i : Get display information in JSON format. May segfault.  // -i 在有些手机上会出现segfault 139错误
+
+ */
 func isMinicapSupported() bool {
-	output, err := runShellOutput("LD_LIBRARY_PATH=/data/local/tmp", "/data/local/tmp/minicap", "-i")
-	if err != nil {
-		return false
-	}
-	var f MinicapInfo
-	if er := json.Unmarshal([]byte(output), &f); er != nil {
-		return false
-	}
-	output, err = runShell(
+	devInfo := getDeviceInfo()
+	width, height := devInfo.Display.Width, devInfo.Display.Height
+	output, err := runShellOutput(
 		"LD_LIBRARY_PATH=/data/local/tmp",
 		"/data/local/tmp/minicap",
-		"-P", fmt.Sprintf("%dx%d@%dx%d/%d", f.Width, f.Height, f.Width, f.Height, f.Rotation),
-		"-s", "2>/dev/null")
+		"-P", fmt.Sprintf("%dx%d@%dx%d/%d", width, height, width, height, deviceRotation),
+		"-t")
 	if err != nil {
 		return false
 	}
-	return bytes.Equal(output[:2], []byte("\xff\xd8")) // JpegFormat
+	outputs := strings.Split(string(output), "\n")
+	if len(outputs) < 2{
+		return false
+	}
+	status := outputs[len(outputs) - 2]
+	return status == "OK"
 }


### PR DESCRIPTION
你好，我使用的是小米手机，在网上找对应版本的minicap.so文件进行替换后；单独启动minicap是可以的，但是使用atx-agent不行；查看源码后发现是使用了-i来判断是否支持minicap，而我这手机这里报了segfault 139错误；感觉不应该以-i来判断是否支持minicap，我这里改成了使用-t，望参考！