### PR TITLE
handle multiline pm path packagename output

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -284,7 +284,12 @@ type PackageInfo struct {
 
 func readPackageInfo(packageName string) (info PackageInfo, err error) {
 	outbyte, err := runShell("pm", "path", packageName)
-	output := strings.TrimSpace(string(outbyte))
+	lines := strings.Split(string(outbyte), "\n")
+	if len(lines) == 0 {
+    	err = errors.New("no output received")
+    return
+	}
+	output := strings.TrimSpace(lines[0])
 	if !strings.HasPrefix(output, "package:") {
 		err = errors.New("package " + strconv.Quote(packageName) + " not found")
 		return


### PR DESCRIPTION
Hello!
Just found a problem handling the return of **adb shell pm path packagename**
I don't know why but it may return more packages and that will cause an error for uiautomator2 when starting the app without specific activities, because  `d.app_info(packagename)` will ask atx-agent to find the package with the wrong name.
```
import uiautomator2 as u2
d = u2.connect()
d.app_info("com.instagram.android")
```
which returns the error:
```
BaseError: stat /data/app/com.instagram.android-bHoeaeqTH_3wNr4o9hp3tw==/base.apk
package:/data/app/com.instagram.android-bHoeaeqTH_3wNr4o9hp3tw==/split_pytorch.apk: no such file or directory
```
because in your code you're removing trailing spaces and \n, so you have a long string which is the mix of the two paths.

For your app, for example, it's only one row:
`d.shell(["pm", "path", "com.github.uiautomator"])`
`ShellResponse(output='package:/data/app/com.github.uiautomator-QhCGbZTc-k5orXu8c81syw==/base.apk\n', exit_code=0)`
And the code works correctly.

For Instagram you have something like that (in the last release):
`ShellResponse(output='package:/data/app/com.instagram.android-bHoeaeqTH_3wNr4o9hp3tw==/base.apk\npackage:/data/app/com.instagram.android-bHoeaeqTH_3wNr4o9hp3tw==/split_pytorch.apk\n', exit_code=0)`
which needs a little bit of string manipulation. 
I've split the output where \n occurs and returned only the first row. That should work with one-row cases and multi-row cases.

